### PR TITLE
Update ClassModel.java

### DIFF
--- a/src/main/java/io/vertx/codegen/ClassModel.java
+++ b/src/main/java/io/vertx/codegen/ClassModel.java
@@ -470,7 +470,7 @@ public class ClassModel implements Model {
         }
         type = typeFactory.create(elem.asType());
         if (getModule() == null) {
-          throw new GenException(elem, "@VertxGen type must have an ancestor package annotated with @ModuleGen");
+          throw new GenException(elem, "@VertxGen type must have an ancestor package annotated with @GenModule");
         }
         ifaceFQCN = elem.asType().toString();
         ifaceSimpleName = elem.getSimpleName().toString();


### PR DESCRIPTION
@ModuleGen -> @GenModule in GenException error message (.

Just backwards. The docs on the ReadMe.md are already correct. Error message was just reporting @VertxGen needs @ModuleGen rather than @GenModule annotation.